### PR TITLE
Add default handlers to the protocol

### DIFF
--- a/examples/sse/client/client.go
+++ b/examples/sse/client/client.go
@@ -25,7 +25,7 @@ func main() {
 		log.Fatalf("failed to create transport: %v", err)
 	}
 
-	protocol, err := mcp.NewProtocol[uint64](mcp.WithTransport(transport))
+	protocol, err := mcp.NewProtocol(mcp.WithTransport[uint64](transport))
 	if err != nil {
 		log.Fatalf("failed to create protocol: %v", err)
 	}

--- a/examples/sse/server/server.go
+++ b/examples/sse/server/server.go
@@ -27,7 +27,7 @@ func main() {
 		log.Fatalf("failed to create transport: %v", err)
 	}
 
-	protocol, err := mcp.NewProtocol[uint64](mcp.WithTransport(transport))
+	protocol, err := mcp.NewProtocol(mcp.WithTransport[uint64](transport))
 	if err != nil {
 		log.Fatalf("failed to create protocol: %v", err)
 	}

--- a/examples/stdio/client/client.go
+++ b/examples/stdio/client/client.go
@@ -22,7 +22,7 @@ func main() {
 
 	transport := mcp.NewStdioTransport[uint64]()
 
-	protocol, err := mcp.NewProtocol[uint64](mcp.WithTransport(transport))
+	protocol, err := mcp.NewProtocol(mcp.WithTransport[uint64](transport))
 	if err != nil {
 		log.Fatalf("failed to create protocol: %v", err)
 	}

--- a/examples/stdio/server/server.go
+++ b/examples/stdio/server/server.go
@@ -24,7 +24,7 @@ func main() {
 
 	transport := mcp.NewStdioTransport[uint64]()
 
-	protocol, err := mcp.NewProtocol[uint64](mcp.WithTransport(transport))
+	protocol, err := mcp.NewProtocol(mcp.WithTransport[uint64](transport))
 	if err != nil {
 		log.Fatalf("failed to create protocol: %v", err)
 	}

--- a/mcp.go
+++ b/mcp.go
@@ -579,13 +579,14 @@ func (j *JSONRPCResponse[T]) UnmarshalJSON(b []byte) error {
 type JSONRPCErrorCode int
 
 const (
-	JSONRPCParseError          JSONRPCErrorCode = -32700
+	JSONRPCConnectionClosed    JSONRPCErrorCode = -1
+	JSONRPCRequestTimeout      JSONRPCErrorCode = -2
 	JSONRPCInvalidRequestError JSONRPCErrorCode = -32600
 	JSONRPCMethodNotFoundError JSONRPCErrorCode = -32601
 	JSONRPCInvalidParamError   JSONRPCErrorCode = -32602
 	JSONRPCInternalError       JSONRPCErrorCode = -32603
-	JSONRPCConnectionClosed    JSONRPCErrorCode = -1
-	JSONRPCRequestTimeout      JSONRPCErrorCode = -2
+	JSONRPCParseError          JSONRPCErrorCode = -32700
+	JSONRPCCancelledError      JSONRPCErrorCode = -32701
 )
 
 type Error struct {

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 )
 
-func MustNewProtocol[T ID](t *testing.T, opts ...Option) *Protocol[T] {
-	p, err := NewProtocol[T](opts...)
+func MustNewProtocol[T ID](t *testing.T, opts ...Option[T]) *Protocol[T] {
+	p, err := NewProtocol(opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -18,7 +18,7 @@ func MustNewProtocol[T ID](t *testing.T, opts ...Option) *Protocol[T] {
 func TestProtocol_Connect(t *testing.T) {
 	t.Run("Successful Connect", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t, WithTransport(tr))
+		p := MustNewProtocol(t, WithTransport[uint64](tr))
 
 		if err := p.Connect(); err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
@@ -30,7 +30,7 @@ func TestProtocol_Connect(t *testing.T) {
 
 	t.Run("Already Connected", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t, WithTransport(tr))
+		p := MustNewProtocol(t, WithTransport[uint64](tr))
 
 		if err := p.Connect(); err != nil {
 			t.Fatalf("Protocol failed to connect: %v", err)
@@ -41,7 +41,7 @@ func TestProtocol_Connect(t *testing.T) {
 	})
 
 	t.Run("Invalid Transport", func(t *testing.T) {
-		invalidProtocol := MustNewProtocol[uint64](t, WithTransport(nil)) // nil transport
+		invalidProtocol := MustNewProtocol(t, WithTransport[uint64](nil)) // nil transport
 		if err := invalidProtocol.Connect(); err == nil || err != ErrInvalidTransport {
 			t.Fatalf("Expected invalid transport error, got: %v", err)
 		}
@@ -51,7 +51,7 @@ func TestProtocol_Connect(t *testing.T) {
 func TestProtocol_Close(t *testing.T) {
 	t.Run("Successful Close", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t, WithTransport(tr))
+		p := MustNewProtocol(t, WithTransport[uint64](tr))
 
 		if err := p.Connect(); err != nil {
 			t.Fatalf("Protocol failed to connect: %v", err)
@@ -66,7 +66,7 @@ func TestProtocol_Close(t *testing.T) {
 
 	t.Run("Close When Already Closed", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t, WithTransport(tr))
+		p := MustNewProtocol(t, WithTransport[uint64](tr))
 
 		if err := p.Connect(); err != nil {
 			t.Fatalf("Protocol failed to connect: %v", err)
@@ -81,7 +81,7 @@ func TestProtocol_Close(t *testing.T) {
 
 	t.Run("Close With Pending Requests", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t, WithTransport(tr))
+		p := MustNewProtocol(t, WithTransport[uint64](tr))
 
 		if err := p.Connect(); err != nil {
 			t.Fatalf("Protocol failed to connect: %v", err)
@@ -102,9 +102,9 @@ func TestProtocol_Close(t *testing.T) {
 func TestProtocol_SendRequest(t *testing.T) {
 	t.Run("Successful Request Response", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t,
-			WithTransport(tr),
-			WithRespTimeout(100*time.Millisecond),
+		p := MustNewProtocol(t,
+			WithTransport[uint64](tr),
+			WithRespTimeout[uint64](100*time.Millisecond),
 		)
 
 		if err := p.Connect(); err != nil {
@@ -146,9 +146,9 @@ func TestProtocol_SendRequest(t *testing.T) {
 	t.Run("Request Timeout", func(t *testing.T) {
 		timeout := 50 * time.Millisecond
 		tr := NewInMemTransport(WithRecvDelay(2 * timeout))
-		p := MustNewProtocol[uint64](t,
-			WithTransport(tr),
-			WithRespTimeout(timeout),
+		p := MustNewProtocol(t,
+			WithTransport[uint64](tr),
+			WithRespTimeout[uint64](timeout),
 		)
 
 		if err := p.Connect(); err != nil {
@@ -174,7 +174,7 @@ func TestProtocol_SendRequest(t *testing.T) {
 
 	t.Run("Request With Canceled Context", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t, WithTransport(tr))
+		p := MustNewProtocol(t, WithTransport[uint64](tr))
 
 		if err := p.Connect(); err != nil {
 			t.Fatalf("Failed to connect: %v", err)
@@ -201,7 +201,7 @@ func TestProtocol_SendRequest(t *testing.T) {
 
 	t.Run("Request After Close", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t, WithTransport(tr))
+		p := MustNewProtocol(t, WithTransport[uint64](tr))
 
 		if err := p.Connect(); err != nil {
 			t.Fatalf("Failed to connect: %v", err)
@@ -225,9 +225,9 @@ func TestProtocol_SendRequest(t *testing.T) {
 
 	t.Run("Concurrent Requests", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t,
-			WithTransport(tr),
-			WithRespTimeout(100*time.Millisecond),
+		p := MustNewProtocol(t,
+			WithTransport[uint64](tr),
+			WithRespTimeout[uint64](100*time.Millisecond),
 		)
 
 		if err := p.Connect(); err != nil {
@@ -274,7 +274,7 @@ func TestProtocol_SendRequest(t *testing.T) {
 func TestProtocol_SendNotification(t *testing.T) {
 	t.Run("Successful Notification", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t, WithTransport(tr))
+		p := MustNewProtocol(t, WithTransport[uint64](tr))
 
 		if err := p.Connect(); err != nil {
 			t.Fatalf("Failed to connect: %v", err)
@@ -298,7 +298,7 @@ func TestProtocol_SendNotification(t *testing.T) {
 
 	t.Run("Notification With Canceled Context", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t, WithTransport(tr))
+		p := MustNewProtocol(t, WithTransport[uint64](tr))
 
 		if err := p.Connect(); err != nil {
 			t.Fatalf("Failed to connect: %v", err)
@@ -325,7 +325,7 @@ func TestProtocol_SendNotification(t *testing.T) {
 
 	t.Run("Notification After Close", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t, WithTransport(tr))
+		p := MustNewProtocol(t, WithTransport[uint64](tr))
 
 		if err := p.Connect(); err != nil {
 			t.Fatalf("Failed to connect: %v", err)
@@ -349,7 +349,7 @@ func TestProtocol_SendNotification(t *testing.T) {
 
 	t.Run("Concurrent Notifications", func(t *testing.T) {
 		tr := NewInMemTransport()
-		p := MustNewProtocol[uint64](t, WithTransport(tr))
+		p := MustNewProtocol(t, WithTransport[uint64](tr))
 
 		if err := p.Connect(); err != nil {
 			t.Fatalf("Failed to connect: %v", err)

--- a/server.go
+++ b/server.go
@@ -82,7 +82,6 @@ func NewServer[T ID](opts ...ServerOption[T]) (*Server[T], error) {
 	}
 
 	// Register core handlers
-	srv.protocol.RegisterRequestHandler(PingRequestMethod, srv.handlePing)
 	srv.protocol.RegisterRequestHandler(InitializeRequestMethod, srv.handleInitialize)
 	srv.protocol.RegisterNotificationHandler(InitializedNotificationMethod, srv.handleInitialized)
 
@@ -159,14 +158,6 @@ func (s *Server[T]) handleInitialize(_ context.Context, req *JSONRPCRequest[T]) 
 		},
 		ID:      req.ID,
 		Version: JSONRPCVersion,
-	}, nil
-}
-
-func (s *Server[T]) handlePing(_ context.Context, req *JSONRPCRequest[T]) (*JSONRPCResponse[T], error) {
-	return &JSONRPCResponse[T]{
-		ID:      req.ID,
-		Version: JSONRPCVersion,
-		Result:  &PingResult{},
 	}, nil
 }
 


### PR DESCRIPTION
This adds some default handlers to the protocol
* Ping handler (moved from server to protocol so client benefits, too)
* Cancel notification handler (closes pending requests)
* Progress handler notification option so client can supply one